### PR TITLE
feat!: add optional mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,40 +36,49 @@ repo = 'kaile256/vim-snatch'
 lazy = 1
 on_event = ['InsertEnter']
 # Or uncomment below.
-# on_map = {i = [
-#  '<Plug>(snatch-ctrl-e)',
-#  '<Plug>(snatch-ctrl-y)',
-# ]}
+# on_map = {i = ['<Plug>(snatch-']}
+# hook_add = '''
+#   imap <C-y> <Plug>(snatch-reg-detached-ctrl-y)
+#   imap <C-e> <Plug>(snatch-reg-detached-ctrl-e)
+# '''
+# hook_source = '''
+#   let g:snatch#no_default_mappings = 1
+# '''
 ```
 
 ## Usage
 
 ### Mappings
 
+This plugin provides several `<Plug>`-mappings.
+Each mappings will snatch text by either motion or updating register.
+Read `doc/snatch.txt` for more details.
+
 ```vim
 " Default mappings
-imap <C-y> <Plug>(snatch-ctrl-y)
-imap <C-e> <Plug>(snatch-ctrl-e)
+imap <C-y> <Plug>(snatch-reg-horizontal-ctrl-y)
+imap <C-e> <Plug>(snatch-reg-horizontal-ctrl-e)
 ```
 
-Or you can predefine the first `{motion}`.
+Or define mappings as your preference.
 
 ```vim
 let g:snatch#no_default_mappings = 1
 
-imap <C-y> <Plug>(snatch-ctrl-y)<Plug>(easymotion-f)
-imap <C-y> <Plug>(snatch-ctrl-y)<Plug>(shot-f)
+imap <C-y> <Plug>(snatch-reg-sensitive-ctrl-y)
+
+" Or you can predefine the first `{motion}`.
+imap <C-y> <Plug>(snatch-reg-horizontal-ctrl-y)<Plug>(easymotion-f)
+imap <C-y> <Plug>(snatch-horizontal-ctrl-y)<Plug>(shot-f)
 
 " Use some tricks for non-recursive {motion}.
 onoremap <SID>f f
-imap <C-y> <Plug>(snatch-ctrl-y)<SID>f
-```
+imap <C-y> <Plug>(snatch-horizontal-ctrl-y)<SID>f
 
-We have another mapping, `<Plug>(snatch-here)`.
-It may be useful with the motions that assumes twice a `{motion}` or more.
-
-```vim
-imap <C-y> <Plug>(snatch-here)<Plug>(easymotion-s)
+" We have another kind of mappings to start sneaking right at the spot.
+" It may be useful with the motions that assumes twice a `{motion}` or more.
+imap <C-y> <Plug>(snatch-reg-detached-here)<Plug>(easymotion-s)
+imap <C-y> <Plug>(snatch-reg-horizontal-here)<Plug>(easymotion-s)
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ including those defined by `:nmap`/`:nnoremap`.
 ## Features
 
 - Accept text-objects: `iw`, `a[`, ...
-  (To be honest, since the feature uses TextYankPost,
-  you have to type `yiw`, or `da[`, etc.)
 
-- Provide no extra `:nmap`pings/`:omap`pings for {motion}.
+  - To be honest, since the feature uses `TextYankPost`,
+    you have to type `yiw`, or `da[`, etc.
+
+- Provide no extra `:nmap`pings/`:omap`pings for `{motion}`.
   Thus, this plugin is hardly interfered with other mappings, but highly
   customizable with the existing fantastic plugins:
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ on_event = ['InsertEnter']
 # Or uncomment below.
 # on_map = {i = ['<Plug>(snatch-']}
 # hook_add = '''
-#   imap <C-y> <Plug>(snatch-reg-detached-ctrl-y)
-#   imap <C-e> <Plug>(snatch-reg-detached-ctrl-e)
+#   imap <C-y> <Plug>(snatch-reg-ctrl-y)
+#   imap <C-e> <Plug>(snatch-reg-ctrl-e)
 # '''
 # hook_source = '''
 #   let g:snatch#no_default_mappings = 1
@@ -79,14 +79,14 @@ imap <C-y> <Plug>(snatch-horizontal-ctrl-y)<SID>f
 
 " We have another kind of mappings to start sneaking right at the spot.
 " It may be useful with the motions that assumes twice a `{motion}` or more.
-imap <C-y> <Plug>(snatch-reg-detached-here)<Plug>(easymotion-s)
+imap <C-y> <Plug>(snatch-reg-here)<Plug>(easymotion-s)
 imap <C-y> <Plug>(snatch-reg-horizontal-here)<Plug>(easymotion-s)
 
 " Suggestion:
 " You might enjoy the trick that snatch texts as soon as cursor has moved.
-imap <C-y> <Plug>(snatch-reg-detached-ctrl-y)y
+imap <C-y> <Plug>(snatch-reg-ctrl-y)y
 " Or name the mapping, using <SID>:
 inoremap <SID>y y
-imap <SID>(snatch-sensitive-ctrl-y) <Plug>(snatch-reg-detached-ctrl-y)<SID>y
+imap <SID>(snatch-sensitive-ctrl-y) <Plug>(snatch-reg-ctrl-y)<SID>y
 imap <C-y> <SID>(snatch-sensitive-ctrl-y)
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ on_event = ['InsertEnter']
 
 ## Usage
 
+### Options
+
+```vim
+" As long as the registers are used to snatch, this plugin will never override the register.
+" Default: '0'
+let g:snatch#clean_registers = '0"abc'
+```
+
 ### Mappings
 
 This plugin provides several `<Plug>`-mappings.
@@ -81,14 +89,4 @@ imap <C-y> <Plug>(snatch-reg-detached-ctrl-y)y
 inoremap <SID>y y
 imap <SID>(snatch-sensitive-ctrl-y) <Plug>(snatch-reg-detached-ctrl-y)<SID>y
 imap <C-y> <SID>(snatch-sensitive-ctrl-y)
-```
-
-### Options
-
-```vim
-" As long as the registers are used to snatch, this plugin will never override
-" the register.
-" Default: '0'
-let g:snatch#clean_registers = '0"abc'
-
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ let g:snatch#clean_registers = '0"abc'
 ### Mappings
 
 This plugin provides several `<Plug>`-mappings.
-Each mappings will snatch text by either motion or updating register.
+Each mappings will snatch text by either motion or intercepting it from the
+register.
 Read `doc/snatch.txt` for more details.
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -1,28 +1,23 @@
 # vim-snatch
 
-vim-snatch replaces `i_CTRL-E`/`i_CTRL-Y`.
-Most of the `{motion}`s are available,
-including those defined by `:nmap`/`:nnoremap`.
+Snatch texts, from Insert mode, by horizontal motion or by `TextYankPost`.
 
-## Features
+## Concept
 
-- Accept text-objects: `iw`, `a[`, ...
+- Unnecessary to set any extra `:nmap`pings/`:omap`pings for `{motion}`.
 
-  - To be honest, since the feature uses `TextYankPost`,
-    you have to type `yiw`, or `da[`, etc.
+- Acceptive of text-objects: `iw`, `a[`, ...
 
-- Provide no extra `:nmap`pings/`:omap`pings for `{motion}`.
-  Thus, this plugin is hardly interfered with other mappings, but highly
-  customizable with the existing fantastic plugins:
+  (To be honest, since the feature works with `TextYankPost`,
+  you have to type `yiw`, or `da[`, etc.,
+  but it won't mess up your register or clipboard.)
+
+- Friendly with the existing mappings of the fantastic plugins:
 
   - [easymotion/vim-easymotion](https://github.com/easymotion/vim-easymotion)
   - [deris/vim-shot-f](https://github.com/deris/vim-shot-f)
   - Text-objects of [machakann/vim-sandwich](https://github.com/machakann/vim-sandwich)
   - ...
-
-- Let us select a line to copy until the cursor moves horizontally or
-  `TextYankPost` is triggered.
-  Thus, this plugin will be more convenient with a sort of easymotion.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Or define mappings as your preference.
 ```vim
 let g:snatch#no_default_mappings = 1
 
-imap <C-y> <Plug>(snatch-reg-sensitive-ctrl-y)
-
 " Or you can predefine the first `{motion}`.
 imap <C-y> <Plug>(snatch-reg-horizontal-ctrl-y)<Plug>(easymotion-f)
 imap <C-y> <Plug>(snatch-horizontal-ctrl-y)<Plug>(shot-f)
@@ -79,6 +77,14 @@ imap <C-y> <Plug>(snatch-horizontal-ctrl-y)<SID>f
 " It may be useful with the motions that assumes twice a `{motion}` or more.
 imap <C-y> <Plug>(snatch-reg-detached-here)<Plug>(easymotion-s)
 imap <C-y> <Plug>(snatch-reg-horizontal-here)<Plug>(easymotion-s)
+
+" Suggestion:
+" You might enjoy the trick that snatch texts as soon as cursor has moved.
+imap <C-y> <Plug>(snatch-reg-detached-ctrl-y)y
+" Or name the mapping, using <SID>:
+inoremap <SID>y y
+imap <SID>(snatch-sensitive-ctrl-y) <Plug>(snatch-reg-detached-ctrl-y)<SID>y
+imap <C-y> <SID>(snatch-sensitive-ctrl-y)
 ```
 
 ### Options

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ imap <C-y> <SID>(snatch-sensitive-ctrl-y)
 ### Options
 
 ```vim
-" While the registers are used to copy, this plugin will never override the
-" register.
+" As long as the registers are used to snatch, this plugin will never override
+" the register.
 " Default: '0'
 let g:snatch#clean_registers = '0"abc'
 

--- a/autoload/snatch.vim
+++ b/autoload/snatch.vim
@@ -52,7 +52,8 @@ function! s:insert_as_motion() abort
   const old_lnum = s:start_pos[1]
   const new_lnum = pos[1]
 
-  if new_lnum != old_lnum || pos == s:start_pos
+  if s:recursive_motion ==# 'vertical'
+        \ && (new_lnum != old_lnum || pos == s:start_pos)
     let s:start_pos = pos
     call s:wait_motions()
     return
@@ -69,30 +70,48 @@ function! s:insert_as_motion() abort
   unlet s:start_pos
 endfunction
 
+function! s:parse_snatch_events() abort
+  const snatch_by = deepcopy(s:config.snatch_by)
+  let s:use_register = index(snatch_by, 'register') >= 0
+  let s:recursive_motion = index(snatch_by, 'any_motion') >= 0 ? 'none'
+        \ : index(snatch_by, 'horizontal_motion') >= 0 ? 'vertical'
+        \ : 'any'
+endfunction
+
 function! s:wait_motions() abort
+  call s:parse_snatch_events()
+
   augroup snatch
     autocmd!
 
-    autocmd CursorMoved * ++once call s:insert_as_motion()
-    autocmd TextYankPost * ++once unlet s:start_pos
+    if s:recursive_motion !=# 'any'
+      autocmd CursorMoved * ++once call s:insert_as_motion()
+      autocmd TextYankPost * ++once unlet s:start_pos
+    endif
 
-    " `TextYankPost` is not allowed to modify texts directly.
-    autocmd TextYankPost * ++once call timer_start(0, expand('<SID>') .'insert_as_register')
-    autocmd TextYankPost * ++once call timer_start(100, expand('<SID>') .'restore_reg')
+    if s:use_register
+      " `TextYankPost` is not allowed to modify texts directly.
+      autocmd TextYankPost * ++once
+            \ call timer_start(0, expand('<SID>') .'insert_as_register')
+      autocmd TextYankPost * ++once
+            \ call timer_start(100, expand('<SID>') .'restore_reg')
 
-    " Although CursorMoved is not always triggered as TextYankPost has been
-    " triggered, once it is triggered, CursorMoved is sometimes earlier than
-    " TextYankPost.
-    autocmd TextYankPost * ++once silent! autocmd! snatch
+      " Although CursorMoved is not always triggered as TextYankPost has been
+      " triggered, once it is triggered, CursorMoved is sometimes earlier than
+      " TextYankPost.
+      autocmd TextYankPost * ++once silent! autocmd! snatch
+    endif
   augroup END
 endfunction
 
-function! snatch#start(...) abort
+function! snatch#start(config) abort
   let s:insert_pos = getpos('.')
   call s:save_reg()
 
-  if a:0
-    exe 'norm! '. a:1
+  let s:config = a:config
+  const pre_keys = s:config.pre_keys
+  if pre_keys !=# ''
+    exe 'norm!' pre_keys
   endif
 
   noautocmd stopinsert

--- a/autoload/snatch.vim
+++ b/autoload/snatch.vim
@@ -46,6 +46,7 @@ function! s:insert_as_motion() abort
   if !exists('s:start_pos')
     let s:start_pos = getpos('.')
     call s:wait_motions()
+    return
   endif
 
   const pos = getpos('.')

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -45,9 +45,9 @@ i_<Plug>(snatch-horizontal-here)             *i_<Plug>(snatch-horizontal-here)*
         As soon as cursor moves horizontally, it'll snatch {motion} text; as
         long as vertically, it waits for {motion}.
 
-i_<Plug>(snatch-reg-detached-ctrl-y)     *i_<Plug>(snatch-reg-detached-ctrl-y)*
-i_<Plug>(snatch-reg-detached-ctrl-e)     *i_<Plug>(snatch-reg-detached-ctrl-e)*
-i_<Plug>(snatch-reg-detached-here)         *i_<Plug>(snatch-reg-detached-here)*
+i_<Plug>(snatch-reg-ctrl-y)                       *i_<Plug>(snatch-reg-ctrl-y)*
+i_<Plug>(snatch-reg-ctrl-e)                       *i_<Plug>(snatch-reg-ctrl-e)*
+i_<Plug>(snatch-reg-here)                           *i_<Plug>(snatch-reg-here)*
 
         Snatch the text to be registered. Any {motion} won't stop snatching.
         See |g:snatch#clean_registers|.
@@ -57,9 +57,8 @@ i_<Plug>(snatch-reg-horizontal-ctrl-e) *i_<Plug>(snatch-reg-horizontal-ctrl-e)*
 i_<Plug>(snatch-reg-horizontal-here)     *i_<Plug>(snatch-reg-horizontal-here)*
 
         Mixed mapping of |<Plug>(snatch-horizontal-ctrl-y)| and
-        |<Plug>(snatch-reg-detached-ctrl-y)|, and the same applies the rest.
-        For the details, follow the respective tags.
-
+        |<Plug>(snatch-reg-ctrl-y)|, and the same applies the rest. For the
+        details, follow the respective tags.
 
 ==============================================================================
 COMPATIBILITY                                             *snatch-compatibility*

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -1,0 +1,69 @@
+*snatch.txt*                Snatch texts as i_CTRL-Y/i_CTRL-E
+
+Version: 1.0.0
+Author: kaile256 <kaile256acc at gmail.com>
+License: MIT license
+
+==============================================================================
+CONTENTS                                                       *snatch-contents*
+
+Introduction            |snatch-introduction|
+Usage                   |snatch-usage|
+  Variable                |snatch-variable|
+  Mapping                 |snatch-mapping|
+Compatibility           |snatch-compatibility|
+
+==============================================================================
+INTRODUCTION                                               *snatch-introduction*
+
+
+==============================================================================
+USAGE                                                             *snatch-usage*
+
+------------------------------------------------------------------------------
+VARIABLE                                                       *snatch-variable*
+
+g:snatch#no_default_mappings                     *g:snatch#no_default_mappings*
+        (default: 0)
+
+g:snatch#clean_registers                             *g:snatch#clean_registers*
+        (default: '0')
+
+        Set in |String|.
+        Using the provided mappings like |<Plug>(snatch-reg-horizontal-ctrl-y)|,
+        |vim-snatch| will snatch texts but won't override the |registers| set
+        in this option, as if to intercept it. (Actually, save & restore the
+        |registers|.) The rest of |registers| works as usual, snatching texts.
+
+------------------------------------------------------------------------------
+MAPPING                                                         *snatch-mapping*
+
+i_<Plug>(snatch-horizontal-ctrl-y)         *i_<Plug>(snatch-horizontal-ctrl-y)*
+i_<Plug>(snatch-horizontal-ctrl-e)         *i_<Plug>(snatch-horizontal-ctrl-e)*
+i_<Plug>(snatch-horizontal-here)             *i_<Plug>(snatch-horizontal-here)*
+
+        As soon as cursor moves horizontally, it'll snatch {motion} text; as
+        long as vertically, it waits for {motion}.
+
+i_<Plug>(snatch-reg-detached-ctrl-y)     *i_<Plug>(snatch-reg-detached-ctrl-y)*
+i_<Plug>(snatch-reg-detached-ctrl-e)     *i_<Plug>(snatch-reg-detached-ctrl-e)*
+i_<Plug>(snatch-reg-detached-here)         *i_<Plug>(snatch-reg-detached-here)*
+
+        Snatch the text to be registered. Any {motion} won't stop snatching.
+        See |g:snatch#clean_registers|.
+
+i_<Plug>(snatch-reg-horizontal-ctrl-y) *i_<Plug>(snatch-reg-horizontal-ctrl-y)*
+i_<Plug>(snatch-reg-horizontal-ctrl-e) *i_<Plug>(snatch-reg-horizontal-ctrl-e)*
+i_<Plug>(snatch-reg-horizontal-here)     *i_<Plug>(snatch-reg-horizontal-here)*
+
+        Mixed mapping of |<Plug>(snatch-horizontal-ctrl-y)| and
+        |<Plug>(snatch-reg-detached-ctrl-y)|, and the same applies the rest.
+        For the details, follow the respective tags.
+
+
+==============================================================================
+COMPATIBILITY                                             *snatch-compatibility*
+
+
+==============================================================================
+vim:ft=help:tw=78:ts=8:sts=8:sw=8:norl:fen

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -24,19 +24,6 @@ inoremap <silent> <Plug>(snatch-horizontal-here) <Cmd>call snatch#start({
       \   'snatch_by': ['horizontal_motion'],
       \ })<CR>
 
-inoremap <silent> <Plug>(snatch-sensitive-ctrl-y) <Cmd>call snatch#start({
-      \   'pre_keys': 'kl',
-      \   'snatch_by': ['any_motion'],
-      \ })<CR>
-inoremap <silent> <Plug>(snatch-sensitive-ctrl-e) <Cmd>call snatch#start({
-      \   'pre_keys': 'jl',
-      \   'snatch_by': ['any_motion'],
-      \ })<CR>
-inoremap <silent> <Plug>(snatch-sensitive-here) <Cmd>call snatch#start({
-      \   'pre_keys': '',
-      \   'snatch_by': ['any_motion'],
-      \ })<CR>
-
 inoremap <silent> <Plug>(snatch-reg-detached-ctrl-y) <Cmd>call snatch#start({
       \   'pre_keys': 'kl',
       \   'snatch_by': ['register'],
@@ -61,19 +48,6 @@ inoremap <silent> <Plug>(snatch-reg-horizontal-ctrl-e) <Cmd>call snatch#start({
 inoremap <silent> <Plug>(snatch-reg-horizontal-here) <Cmd>call snatch#start({
       \   'pre_keys': '',
       \   'snatch_by': ['register', 'horizontal_motion'],
-      \ })<CR>
-
-inoremap <silent> <Plug>(snatch-reg-sensitive-ctrl-y) <Cmd>call snatch#start({
-      \   'pre_keys': 'kl',
-      \   'snatch_by': ['register', 'any_motion'],
-      \ })<CR>
-inoremap <silent> <Plug>(snatch-reg-sensitive-ctrl-e) <Cmd>call snatch#start({
-      \   'pre_keys': 'jl',
-      \   'snatch_by': ['register', 'any_motion'],
-      \ })<CR>
-inoremap <silent> <Plug>(snatch-reg-sensitive-here) <Cmd>call snatch#start({
-      \   'pre_keys': '',
-      \   'snatch_by': ['register', 'any_motion'],
       \ })<CR>
 
 if !get(g:, 'snatch#no_default_mappings', 0)

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -24,15 +24,15 @@ inoremap <silent> <Plug>(snatch-horizontal-here) <Cmd>call snatch#start({
       \   'snatch_by': ['horizontal_motion'],
       \ })<CR>
 
-inoremap <silent> <Plug>(snatch-reg-detached-ctrl-y) <Cmd>call snatch#start({
+inoremap <silent> <Plug>(snatch-reg-ctrl-y) <Cmd>call snatch#start({
       \   'pre_keys': 'kl',
       \   'snatch_by': ['register'],
       \ })<CR>
-inoremap <silent> <Plug>(snatch-reg-detached-ctrl-e) <Cmd>call snatch#start({
+inoremap <silent> <Plug>(snatch-reg-ctrl-e) <Cmd>call snatch#start({
       \   'pre_keys': 'jl',
       \   'snatch_by': ['register'],
       \ })<CR>
-inoremap <silent> <Plug>(snatch-reg-detached-here) <Cmd>call snatch#start({
+inoremap <silent> <Plug>(snatch-reg-here) <Cmd>call snatch#start({
       \   'pre_keys': '',
       \   'snatch_by': ['register'],
       \ })<CR>

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -1,7 +1,6 @@
 let g:loaded_snatch = 1
 
-let g:snatch#clean_registers =
-      \ get(g:, 'snatch#clean_registers', '0')
+let g:snatch#clean_registers = get(g:, 'snatch#clean_registers', '0')
 
 " Note: Use <Cmd> for the first hand mappings.
 " - <Esc> invokes `InsertLeave`.
@@ -12,17 +11,73 @@ let g:snatch#clean_registers =
 "   inoremap <C-y> <Cmd>call s:foo("\<Plug>(bar)")<CR>
 "   ```
 "   throws the error E5522.
-inoremap <silent> <Plug>(snatch-ctrl-y)
-      \ <Cmd>call snatch#start('kl')<CR>
+inoremap <silent> <Plug>(snatch-horizontal-ctrl-y) <Cmd>call snatch#start({
+      \   'pre_keys': 'kl',
+      \   'snatch_by': ['horizontal_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-horizontal-ctrl-e) <Cmd>call snatch#start({
+      \   'pre_keys': 'jl',
+      \   'snatch_by': ['horizontal_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-horizontal-here) <Cmd>call snatch#start({
+      \   'pre_keys': '',
+      \   'snatch_by': ['horizontal_motion'],
+      \ })<CR>
 
-inoremap <silent> <Plug>(snatch-ctrl-e)
-      \ <Cmd>call snatch#start('jl')<CR>
+inoremap <silent> <Plug>(snatch-sensitive-ctrl-y) <Cmd>call snatch#start({
+      \   'pre_keys': 'kl',
+      \   'snatch_by': ['any_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-sensitive-ctrl-e) <Cmd>call snatch#start({
+      \   'pre_keys': 'jl',
+      \   'snatch_by': ['any_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-sensitive-here) <Cmd>call snatch#start({
+      \   'pre_keys': '',
+      \   'snatch_by': ['any_motion'],
+      \ })<CR>
 
-inoremap <silent> <Plug>(snatch-here)
-      \ <Cmd>call snatch#start()<CR>
+inoremap <silent> <Plug>(snatch-reg-detached-ctrl-y) <Cmd>call snatch#start({
+      \   'pre_keys': 'kl',
+      \   'snatch_by': ['register'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-detached-ctrl-e) <Cmd>call snatch#start({
+      \   'pre_keys': 'jl',
+      \   'snatch_by': ['register'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-detached-here) <Cmd>call snatch#start({
+      \   'pre_keys': '',
+      \   'snatch_by': ['register'],
+      \ })<CR>
+
+inoremap <silent> <Plug>(snatch-reg-horizontal-ctrl-y) <Cmd>call snatch#start({
+      \   'pre_keys': 'kl',
+      \   'snatch_by': ['register', 'horizontal_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-horizontal-ctrl-e) <Cmd>call snatch#start({
+      \   'pre_keys': 'jl',
+      \   'snatch_by': ['register', 'horizontal_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-horizontal-here) <Cmd>call snatch#start({
+      \   'pre_keys': '',
+      \   'snatch_by': ['register', 'horizontal_motion'],
+      \ })<CR>
+
+inoremap <silent> <Plug>(snatch-reg-sensitive-ctrl-y) <Cmd>call snatch#start({
+      \   'pre_keys': 'kl',
+      \   'snatch_by': ['register', 'any_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-sensitive-ctrl-e) <Cmd>call snatch#start({
+      \   'pre_keys': 'jl',
+      \   'snatch_by': ['register', 'any_motion'],
+      \ })<CR>
+inoremap <silent> <Plug>(snatch-reg-sensitive-here) <Cmd>call snatch#start({
+      \   'pre_keys': '',
+      \   'snatch_by': ['register', 'any_motion'],
+      \ })<CR>
 
 if !get(g:, 'snatch#no_default_mappings', 0)
-  imap <C-y> <Plug>(snatch-ctrl-y)
-  imap <C-e> <Plug>(snatch-ctrl-e)
+  imap <C-y> <Plug>(snatch-reg-horizontal-ctrl-y)
+  imap <C-e> <Plug>(snatch-reg-horizontal-ctrl-e)
 endif
 


### PR DESCRIPTION
Add `i_<Plug>(snatch-horizontal-ctrl-y)`, `i_<Plug>(snatch-reg-ctrl-e)`,
`i_<Plug>(snatch-reg-horizontal-here)` (the last one replaces the old
`<Plug>(snatch-here)`), and so forth.

## BREAKING CHANGE:
All the old mappings like `<Plug>(snatch-ctrl-y)` are removed.