### PR TITLE
fix: deal with snatching from another window

### DIFF
--- a/autoload/snatch/augroup.vim
+++ b/autoload/snatch/augroup.vim
@@ -7,6 +7,7 @@ function! snatch#augroup#begin(name) abort
   const group = 'snatch/'. a:name
   let s:groups += [ group ]
   exe 'augroup' group
+  return group
 endfunction
 
 function! snatch#augroup#end() abort
@@ -14,13 +15,14 @@ function! snatch#augroup#end() abort
   exe 'augroup END'
 endfunction
 
-function! snatch#augroup#clear() abort
+function! snatch#augroup#clear(...) abort
   " Note: This function is supposed to be called before Snatch.*Post.
 
-  let groups = s:groups
+  let groups = a:0 ? deepcopy(a:000) : s:groups
   call uniq(groups)
   for grp in groups
     exe 'silent! autocmd!' grp
+    let idx = index(s:groups, grp)
+    call remove(s:groups, idx)
   endfor
-  let s:groups = []
 endfunction

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -13,6 +13,11 @@ if s:use_guicursor
   const s:hl_cursor_config = 'n-o:block-SnatchCursor'
 endif
 
+function! s:abort_if_no_strategies_are_available() abort
+  if !empty(s:stat.snatch_by.get()) | return | endif
+  call snatch#common#abort()
+endfunction
+
 augroup snatch/watch
   " For the simplicity, keep `is_sneaking` managed within this augroup.
 
@@ -25,6 +30,8 @@ augroup snatch/watch
 
   autocmd User SnatchAbortedInPart-horizontal_motion
         \ call s:stat.snatch_by.remove('horizontal_motion')
+  autocmd User SnatchAbortedInPart-horizontal_motion
+        \ call s:abort_if_no_strategies_are_available()
 augroup END
 
 function! s:wait_if_surely_in_normal_mode(...) abort

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -24,6 +24,15 @@ augroup snatch/watch
   autocmd User SnatchCancelledPost call s:stat.is_sneaking.set(v:false)
 augroup END
 
+function! s:wait_if_surely_in_normal_mode(...) abort
+  if mode() !=# 'n'
+    call timer_start(50, expand('<SID>') .'wait_if_surely_in_normal_mode')
+    return
+  endif
+
+  call s:wait()
+endfunction
+
 function! s:save_state(config) abort
   call s:stat.win_id.set(win_getid())
   call s:stat.prev_mode.set(a:config.prev_mode)
@@ -67,7 +76,9 @@ function! snatch#common#prepare(config) abort
     exe 'norm!' pre_keys
   endif
 
-  call s:wait()
+  " Note: Although `:stopinsert` above, and even the success of command,
+  " `execute 'normal!' prekeys`, we're NOT in normal mode yet.
+  call s:wait_if_surely_in_normal_mode()
 endfunction
 
 function! s:wait() abort

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -22,6 +22,9 @@ augroup snatch/watch
 
   autocmd User SnatchAbortedPost   call s:stat.is_sneaking.set(v:false)
   autocmd User SnatchCancelledPost call s:stat.is_sneaking.set(v:false)
+
+  autocmd User SnatchAbortedInPart-horizontal_motion
+        \ call s:stat.snatch_by.remove('horizontal_motion')
 augroup END
 
 function! s:wait_if_surely_in_normal_mode(...) abort

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -36,8 +36,13 @@ endfunction
 function! s:save_state(config) abort
   call s:stat.win_id.set(win_getid())
   call s:stat.prev_mode.set(a:config.prev_mode)
+
+  const once_by = get(a:config, 'once_by', [])
+  call s:stat.once_by.set(once_by)
   call s:stat.snatch_by.set(get(a:config, 'snatch_by', []))
-  call s:stat.once_by.set(get(a:config, 'once_by', []))
+  for ob in once_by
+    call s:stat.snatch_by.add(ob)
+  endfor
 endfunction
 
 function! s:set_another_cursorhl() abort

--- a/autoload/snatch/motion.vim
+++ b/autoload/snatch/motion.vim
@@ -47,9 +47,9 @@ function! snatch#motion#wait(oneshot) abort
   autocmd!
   " Creating a new window triggers CursorMoved, which often makes unexpected
   " snatching. WinNew did not fix this problem.
-  exe 'autocmd WinNew,WinEnter * ++once'
+  execute 'autocmd WinNew,WinEnter * ++once'
         \  'call s:abort_horizontal_detection(' string(au_name) ')'
-  exe 'autocmd CursorMoved * ++once'
+  execute 'autocmd CursorMoved * ++once'
         \ 'call s:insert_on_horizontal_motion(' a:oneshot ')'
   call snatch#augroup#end()
 endfunction

--- a/autoload/snatch/motion.vim
+++ b/autoload/snatch/motion.vim
@@ -6,6 +6,7 @@ function! s:abort_horizontal_detection(au_name) abort
   " Note: FileType invokes after WinNew or WinEnter does so that it's hard to
   " abort just on specific filetypes.
   call snatch#augroup#clear(a:au_name)
+  doautocmd <nomodeline> User SnatchAbortedInPart-horizontal_motion
 endfunction
 
 function! s:insert_on_horizontal_motion(au_name, oneshot) abort

--- a/autoload/snatch/status.vim
+++ b/autoload/snatch/status.vim
@@ -20,6 +20,20 @@ function! s:stat__is_reset() abort dict
 endfunction
 let s:stat.is_reset = funcref('s:stat__is_reset')
 
+function! s:stat__add(item) abort dict
+  " Keep the item unique in list.
+  if index(self.val, a:item) >= 0 | return | endif
+  call add(self.val, a:item)
+endfunction
+let s:stat.add = funcref('s:stat__add')
+
+function! s:stat__remove(item) abort dict
+  const idx = index(self.val, a:item)
+  if idx == -1 | return | endif
+  call remove(self.val, idx)
+endfunction
+let s:stat.remove = funcref('s:stat__remove')
+
 function! snatch#status#new(default) abort
   let stat = deepcopy(s:stat)
   let stat.default = a:default

--- a/test/.themisrc
+++ b/test/.themisrc
@@ -1,0 +1,5 @@
+call themis#option('recursive', 1)
+
+let s:helper = themis#helper('assert')
+call themis#helper('command').with(s:helper)
+

--- a/test/augroup.vimspec
+++ b/test/augroup.vimspec
@@ -1,0 +1,12 @@
+Describe augroup#clear()
+  It can remove just a specified augroup
+    let au_name = snatch#augroup#begin('bar')
+    autocmd BufRead * echo 'foo'
+    call snatch#augroup#end()
+    let au_contents = execute('autocmd '. au_name)
+    Assert NotEmpty(au_contents)
+    call snatch#augroup#clear(au_name)
+    let au_contents = execute('autocmd '. au_name)
+    Assert Same(au_contents, "\n--- Autocommands ---")
+  End
+End


### PR DESCRIPTION
## TODO
- [x] Remove only `horizontal_motion` from running strategies.
- [x] Invoke `User SnatchAbortedPre/Post` if none strategies are left.