### PR TITLE
refactor!(status): substitute read-only status variable for the old snatch#status()

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ let g:snatch#clean_registers = '0"abc'
 let g:snatch#cmd#position_marker = '┃'
 ```
 
+### Status
+
+You can watch current snatch status by `g:snatch_status`.
+
+```vim
+" Add the snippet in your vimrc before any other scripts that use
+" g:snatch_status unless you're sure it's unnecessary.
+if !exists('g:snatch_status')
+  let g:snatch_status = {}
+endif
+```
+
+If you'd like to leave insert mode, add the snippets below in your vimrc.
+
+```vim
+augroup InsertLeaveAfterSnatching
+  autocmd!
+  " Note: `:stopinsert` instead is useless here.
+  autocmd User SnatchInsertPost if g:snatch_status.prev_mode ==# 'i' |
+        \   call feedkeys("\<Esc>")
+        \ | endif
+augroup END
+```
+
 ### Mappings
 
 This plugin provides several `<Plug>`-mappings.

--- a/autoload/snatch.vim
+++ b/autoload/snatch.vim
@@ -1,7 +1,3 @@
-function! snatch#status() abort
-  return snatch#common#status()
-endfunction
-
 function! snatch#abort() abort
   call snatch#common#abort()
 endfunction

--- a/autoload/snatch/cmd.vim
+++ b/autoload/snatch/cmd.vim
@@ -26,7 +26,7 @@ function! s:prepare() abort
   call s:save_cmdline()
 
   const config = {
-        \ 'snatch_by': ['operator'],
+        \ 'strategies': ['operator'],
         \ 'prev_mode': s:save_cmdtype,
         \ }
   call snatch#common#prepare(config)

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -3,7 +3,6 @@ let s:stat.win_id = snatch#status#new(0).register('win_id')
 let s:stat.insert_pos = snatch#status#new([]).register('insert_pos')
 let s:stat.prev_mode = snatch#status#new('NONE').register('prev_mode')
 let s:stat.strategies = snatch#status#new([]).register('strategies')
-let s:stat.once_by = snatch#status#new([]).register('once_by')
 let s:stat.is_sneaking = snatch#status#new(v:false).register('is_sneaking')
 
 const s:is_cmdline_mode = '^[-:>/?@=]$'
@@ -46,11 +45,7 @@ endfunction
 function! s:save_state(config) abort
   call s:stat.win_id.set(win_getid())
   call s:stat.prev_mode.set(a:config.prev_mode)
-
-  const once_by = get(a:config, 'once_by', [])
-  call s:stat.once_by.set(once_by)
   call s:stat.strategies.set(get(a:config, 'strategies', []))
-  call s:stat.strategies.extend(once_by)
 endfunction
 
 function! s:set_another_cursorhl() abort
@@ -106,10 +101,8 @@ function! s:wait() abort
   autocmd BufWinLeave <buffer> ++once call snatch#common#abort()
   call snatch#augroup#end()
 
-  const once_by = deepcopy(s:stat.once_by.get())
-  const oneshot_hor = index(once_by, 'horizontal_motion') >= 0
-
   const strategies = deepcopy(s:stat.strategies.get())
+  const oneshot_hor = index(strategies, 'oneshot_horizontal') >= 0
   if oneshot_hor || index(strategies, 'horizontal_motion') >= 0
     call snatch#motion#wait(oneshot_hor)
   endif

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -183,12 +183,3 @@ function! snatch#common#insert(chars) abort
   call snatch#common#stop()
   doautocmd <nomodeline> User SnatchInsertPost
 endfunction
-
-function! snatch#common#status() abort
-  let stat = {}
-  for key in keys(s:stat)
-    let val = s:stat[key].get()
-    let stat[key] = val
-  endfor
-  return stat
-endfunction

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -1,10 +1,10 @@
 let s:stat = {}
-let s:stat.win_id = snatch#status#new(0)
-let s:stat.insert_pos = snatch#status#new([])
-let s:stat.prev_mode = snatch#status#new('NONE')
-let s:stat.snatch_by = snatch#status#new([])
-let s:stat.once_by = snatch#status#new([])
-let s:stat.is_sneaking = snatch#status#new(v:false)
+let s:stat.win_id = snatch#status#new(0).register('win_id')
+let s:stat.insert_pos = snatch#status#new([]).register('insert_pos')
+let s:stat.prev_mode = snatch#status#new('NONE').register('prev_mode')
+let s:stat.snatch_by = snatch#status#new([]).register('snatch_by')
+let s:stat.once_by = snatch#status#new([]).register('once_by')
+let s:stat.is_sneaking = snatch#status#new(v:false).register('is_sneaking')
 
 const s:is_cmdline_mode = '^[-:>/?@=]$'
 

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -28,7 +28,10 @@ augroup snatch/watch
   autocmd User SnatchCancelledPost call s:stat.is_sneaking.set(v:false)
 
   autocmd User SnatchAbortedInPart-horizontal_motion
-        \ call s:stat.strategies.remove('horizontal_motion')
+        \ call s:stat.strategies.remove(
+        \ s:oneshot_hor
+        \ ? 'oneshot_horizontal'
+        \ : 'horizontal_motion')
   autocmd User SnatchAbortedInPart-horizontal_motion
         \ call s:abort_if_no_strategies_are_available()
 augroup END
@@ -102,9 +105,9 @@ function! s:wait() abort
   call snatch#augroup#end()
 
   const strategies = deepcopy(s:stat.strategies.get())
-  const oneshot_hor = index(strategies, 'oneshot_horizontal') >= 0
-  if oneshot_hor || index(strategies, 'horizontal_motion') >= 0
-    call snatch#motion#wait(oneshot_hor)
+  let s:oneshot_hor = index(strategies, 'oneshot_horizontal') >= 0
+  if s:oneshot_hor || index(strategies, 'horizontal_motion') >= 0
+    call snatch#motion#wait(s:oneshot_hor)
   endif
 
   if index(strategies, 'register') >= 0

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -1,6 +1,4 @@
 let s:stat = {}
-let s:stat.win_id = snatch#status#new(0).register('win_id')
-let s:stat.insert_pos = snatch#status#new([]).register('insert_pos')
 let s:stat.prev_mode = snatch#status#new('NONE').register('prev_mode')
 let s:stat.strategies = snatch#status#new([]).register('strategies')
 let s:stat.is_sneaking = snatch#status#new(v:false).register('is_sneaking')
@@ -47,7 +45,6 @@ function! s:wait_if_surely_in_normal_mode(...) abort
 endfunction
 
 function! s:save_state(config) abort
-  call s:stat.win_id.set(win_getid())
   call s:stat.prev_mode.set(a:config.prev_mode)
   call s:stat.strategies.set(get(a:config, 'strategies', []))
 endfunction

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -2,7 +2,7 @@ let s:stat = {}
 let s:stat.win_id = snatch#status#new(0).register('win_id')
 let s:stat.insert_pos = snatch#status#new([]).register('insert_pos')
 let s:stat.prev_mode = snatch#status#new('NONE').register('prev_mode')
-let s:stat.snatch_by = snatch#status#new([]).register('snatch_by')
+let s:stat.strategies = snatch#status#new([]).register('strategies')
 let s:stat.once_by = snatch#status#new([]).register('once_by')
 let s:stat.is_sneaking = snatch#status#new(v:false).register('is_sneaking')
 
@@ -14,7 +14,7 @@ if s:use_guicursor
 endif
 
 function! s:abort_if_no_strategies_are_available() abort
-  if !empty(s:stat.snatch_by.get()) | return | endif
+  if !empty(s:stat.strategies.get()) | return | endif
   call snatch#common#abort()
 endfunction
 
@@ -29,7 +29,7 @@ augroup snatch/watch
   autocmd User SnatchCancelledPost call s:stat.is_sneaking.set(v:false)
 
   autocmd User SnatchAbortedInPart-horizontal_motion
-        \ call s:stat.snatch_by.remove('horizontal_motion')
+        \ call s:stat.strategies.remove('horizontal_motion')
   autocmd User SnatchAbortedInPart-horizontal_motion
         \ call s:abort_if_no_strategies_are_available()
 augroup END
@@ -49,8 +49,8 @@ function! s:save_state(config) abort
 
   const once_by = get(a:config, 'once_by', [])
   call s:stat.once_by.set(once_by)
-  call s:stat.snatch_by.set(get(a:config, 'snatch_by', []))
-  call s:stat.snatch_by.extend(once_by)
+  call s:stat.strategies.set(get(a:config, 'strategies', []))
+  call s:stat.strategies.extend(once_by)
 endfunction
 
 function! s:set_another_cursorhl() abort
@@ -109,12 +109,12 @@ function! s:wait() abort
   const once_by = deepcopy(s:stat.once_by.get())
   const oneshot_hor = index(once_by, 'horizontal_motion') >= 0
 
-  const snatch_by = deepcopy(s:stat.snatch_by.get())
-  if oneshot_hor || index(snatch_by, 'horizontal_motion') >= 0
+  const strategies = deepcopy(s:stat.strategies.get())
+  if oneshot_hor || index(strategies, 'horizontal_motion') >= 0
     call snatch#motion#wait(oneshot_hor)
   endif
 
-  if index(snatch_by, 'register') >= 0
+  if index(strategies, 'register') >= 0
     call snatch#register#wait()
   endif
 

--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -4,6 +4,7 @@ let s:stat.insert_pos = snatch#status#new([]).register('insert_pos')
 let s:stat.prev_mode = snatch#status#new('NONE').register('prev_mode')
 let s:stat.strategies = snatch#status#new([]).register('strategies')
 let s:stat.is_sneaking = snatch#status#new(v:false).register('is_sneaking')
+let s:stat.pre_keys = snatch#status#new('').register('pre_keys')
 
 const s:is_cmdline_mode = '^[-:>/?@=]$'
 
@@ -83,6 +84,7 @@ function! snatch#common#prepare(config) abort
   call s:set_another_cursorhl()
 
   const pre_keys = get(a:config, 'pre_keys', '')
+  call s:stat.pre_keys.set(pre_keys)
   if pre_keys !=# ''
     exe 'norm!' pre_keys
   endif

--- a/autoload/snatch/ins.vim
+++ b/autoload/snatch/ins.vim
@@ -1,5 +1,5 @@
-let s:win_id = snatch#status#new(0)
-let s:insert_pos = snatch#status#new([])
+let s:win_id = snatch#status#new(0).register('win_id')
+let s:insert_pos = snatch#status#new([]).register('insert_pos')
 
 function! s:highlight_insert_pos() abort
   let [l, c] = s:insert_pos.get()[1 : 2]

--- a/autoload/snatch/status.vim
+++ b/autoload/snatch/status.vim
@@ -1,6 +1,13 @@
 let g:snatch_status = {}
+lockvar g:snatch_status
 
 let s:stat = {}
+
+function! s:update_status(name, val) abort
+  unlockvar g:snatch_status
+  let g:snatch_status[a:name] = deepcopy(a:val)
+  lockvar g:snatch_status
+endfunction
 
 function! s:stat__get() abort dict
   return self.val
@@ -17,7 +24,7 @@ function! s:stat__set(val) abort dict
   call self.validate_type(a:val)
   let self.val = a:val
   if !has_key(self, 'name') | return | endif
-  let g:snatch_status[self.name] = a:val
+  call s:update_status(self.name, a:val)
 endfunction
 let s:stat.set = funcref('s:stat__set')
 
@@ -48,12 +55,13 @@ function! s:stat__remove(item) abort dict
   const idx = index(self.val, a:item)
   if idx == -1 | return | endif
   call remove(self.val, idx)
+  call s:update_status(self.name, self.val)
 endfunction
 let s:stat.remove = funcref('s:stat__remove')
 
 function! s:stat__register(name) abort dict
   let self.name = a:name
-  let g:snatch_status[a:name] = self.default
+  call s:update_status(a:name, self.default)
   " Expect method chaining, following #new() at once.
   return self
 endfunction

--- a/autoload/snatch/status.vim
+++ b/autoload/snatch/status.vim
@@ -1,3 +1,5 @@
+let g:snatch_status = {}
+
 let s:stat = {}
 
 function! s:stat__get() abort dict
@@ -14,6 +16,8 @@ let s:stat.validate_type = funcref('s:stat__validate_type')
 function! s:stat__set(val) abort dict
   call self.validate_type(a:val)
   let self.val = a:val
+  if !has_key(self, 'name') | return | endif
+  let g:snatch_status[self.name] = a:val
 endfunction
 let s:stat.set = funcref('s:stat__set')
 
@@ -46,6 +50,14 @@ function! s:stat__remove(item) abort dict
   call remove(self.val, idx)
 endfunction
 let s:stat.remove = funcref('s:stat__remove')
+
+function! s:stat__register(name) abort dict
+  let self.name = a:name
+  let g:snatch_status[a:name] = self.default
+  " Expect method chaining, following #new() at once.
+  return self
+endfunction
+let s:stat.register = funcref('s:stat__register')
 
 function! snatch#status#new(default) abort
   let stat = deepcopy(s:stat)

--- a/autoload/snatch/status.vim
+++ b/autoload/snatch/status.vim
@@ -18,7 +18,7 @@ endfunction
 let s:stat.set = funcref('s:stat__set')
 
 function! s:stat__reset() abort dict
-  let self.val = self.default
+  call self.set(self.default)
 endfunction
 let s:stat.reset = funcref('s:stat__reset')
 

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -103,8 +103,6 @@ USAGE                                                             *snatch-usage*
 ------------------------------------------------------------------------------
 FUNCTION                                                       *snatch-function*
 
-snatch#status()                                               *snatch#status()*
-
 snatch#abort()                                                 *snatch#abort()*
 
         Forcibly stop |Sneaking| mode (practically, |Normal| mode), staying in
@@ -341,6 +339,8 @@ A. Add the following snippet in your vimrc.
 ==============================================================================
 COMPATIBILITY                                             *snatch-compatibility*
 
+2021-04-26
+* Remove snatch#status() in favor of g:snatch_status.
 
 ==============================================================================
 vim:ft=help:tw=78:ts=8:sts=8:sw=8:norl:fen:nojs

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -84,6 +84,15 @@ We have three strategy options for |snatching| in |sneaking| process.
         horizontal_motion       As soon as cursor has moved in the same line,
                                 The text being |snatch|ed must be within a line.
 
+        oneshot_horizontal      Almost the same as "horizontal_motion", but,
+                                once cursor moved vertically, this strategy
+                                will be dropped in current |sneaking|. When
+                                the strategy is the last one, current
+                                |snatching| process is aborted; otherwise, keep
+                                |sneaking| with the rest strategies. Besides,
+                                adopting "horizontal_motion" together causes
+                                undefined behavior.
+
         operator                Get into |Operator-pending| mode. Only available
                                 in |Cmdline| mode. See |snatch-faq| below if you
                                 want to do |snatch|ing via |operator-pending| mode.

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -135,10 +135,14 @@ g:snatch_status                                               *g:snatch_status*
         strategies      Return a |List| of the last available |snatch-strategies|.
         prev_mode       Return a character, either 'i' as |Insert| mode or one
                         of the value you see in |getcmdtype()| as |Cmdline| mode.
-        insert_pos      Return the |List| in the format that |getcurpos()|
-                        returns.
         win_id          Return the |window-ID| for the window where current
-                        |sneaking| has started.
+                        |sneaking| has started. It only matters if "prev_mode"
+                        returns 'i'.
+        insert_pos      Return the |List| in the format that |getcurpos()|
+                        returns. It only matters if "prev_mode" returns 'i'.
+        pre_keys        Returns the predefined key sequence to adjust cursor
+                        to expected position in |snatch-readying| process. It
+                        only matters if "prev_mode" returns 'i'.
 
 g:snatch#no_default_mappings                     *g:snatch#no_default_mappings*
         (default: 0)

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -127,6 +127,21 @@ snatch#cancel()                                               *snatch#cancel()*
 ------------------------------------------------------------------------------
 VARIABLE                                                       *snatch-variable*
 
+g:snatch_status                                               *g:snatch_status*
+
+        Readonly |Dictionary| to represent the last |snatching| status.
+
+        Keys:
+
+        is_sneaking     Return `v:true` if |sneaking|; otherwise, `v:false`.
+        strategies      Return a |List| of the last available |snatch-strategies|.
+        prev_mode       Return a character, either 'i' as |Insert| mode or one
+                        of the value you see in |getcmdtype()| as |Cmdline| mode.
+        insert_pos      Return the |List| in the format that |getcurpos()|
+                        returns.
+        win_id          Return the |window-ID| for the window where current
+                        |sneaking| has started.
+
 g:snatch#no_default_mappings                     *g:snatch#no_default_mappings*
         (default: 0)
 

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -74,19 +74,17 @@ inoremap <silent> <SID>(snatch-hor-or-reg-here)
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-ctrl-y)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'kl',
-      \   'once_by': ['horizontal_motion'],
-      \   'strategies': ['register'],
+      \   'strategies': ['register', 'oneshot_horizontal'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-ctrl-e)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'jl',
-      \   'once_by': ['horizontal_motion'],
-      \   'strategies': ['register'],
+      \   'strategies': ['register', 'oneshot_horizontal'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-here)
       \ <Cmd>call snatch#ins#start({
       \   'once_by': ['horizontal_motion'],
-      \   'strategies': ['register'],
+      \   'strategies': ['register', 'oneshot_horizontal'],
       \ })<CR>
 
 imap <Plug>(snatch-horizontal-ctrl-y)         <SID>(snatch-horizontal-ctrl-y)

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -29,64 +29,64 @@ cnoremap <silent> <Plug>(snatch-operator) <C-\>e snatch#cmd#operator()<CR>
 inoremap <silent> <SID>(snatch-horizontal-ctrl-y)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'kl',
-      \   'snatch_by': ['horizontal_motion'],
+      \   'strategies': ['horizontal_motion'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-horizontal-ctrl-e)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'jl',
-      \   'snatch_by': ['horizontal_motion'],
+      \   'strategies': ['horizontal_motion'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-horizontal-here)
       \ <Cmd>call snatch#ins#start({
-      \   'snatch_by': ['horizontal_motion'],
+      \   'strategies': ['horizontal_motion'],
       \ })<CR>
 
 inoremap <silent> <SID>(snatch-reg-ctrl-y)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'kl',
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-reg-ctrl-e)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'jl',
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-reg-here)
       \ <Cmd>call snatch#ins#start({
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 
 inoremap <silent> <SID>(snatch-hor-or-reg-ctrl-y)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'kl',
-      \   'snatch_by': ['register', 'horizontal_motion'],
+      \   'strategies': ['register', 'horizontal_motion'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-hor-or-reg-ctrl-e)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'jl',
-      \   'snatch_by': ['register', 'horizontal_motion'],
+      \   'strategies': ['register', 'horizontal_motion'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-hor-or-reg-here)
       \ <Cmd>call snatch#ins#start({
-      \   'snatch_by': ['register', 'horizontal_motion'],
+      \   'strategies': ['register', 'horizontal_motion'],
       \ })<CR>
 
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-ctrl-y)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'kl',
       \   'once_by': ['horizontal_motion'],
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-ctrl-e)
       \ <Cmd>call snatch#ins#start({
       \   'pre_keys': 'jl',
       \   'once_by': ['horizontal_motion'],
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 inoremap <silent> <SID>(snatch-oneshot-hor-or-reg-here)
       \ <Cmd>call snatch#ins#start({
       \   'once_by': ['horizontal_motion'],
-      \   'snatch_by': ['register'],
+      \   'strategies': ['register'],
       \ })<CR>
 
 imap <Plug>(snatch-horizontal-ctrl-y)         <SID>(snatch-horizontal-ctrl-y)


### PR DESCRIPTION
Related to #36 

~TODO:~
~- [ ]  `insert_pos` should be replaced by `[lnum, col]` format, instead of those that `getcurpos()` returns; thus, user can `call cursor()` directly as needed.~
~- [ ] Save `cmdpos` for previously cmdline-mode status.~
~- [ ] Save `snatched_pos`, in `[lnum, col]`, where a text has been snatched at last.~