### PR TITLE
feat(map): provide mapping to force to start snatching even with popup menu visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,26 @@ inoremap <SID>y y
 imap <SID>(snatch-operator-ctrl-y) <Plug>(snatch-reg-ctrl-y)<SID>y
 imap <C-y> <SID>(snatch-operator-ctrl-y)
 ```
+
+#### Deal with popup menu
+
+We should set alternative key sequences in the case `pumvisible()` returns `1`
+(usually in completion);
+otherwise, we would let [vim-snatch](https://github.com/kaile256/vim-snatch)
+do unexpected behavior. You have options:
+
+- Just use default mappings. You don't have to care about the matter any
+  longer.
+- Map arbitrary keys to as many of the provided `<Plug>`-mappings as your
+  preference. See the example below:
+
+```vim
+let g:snatch#no_default_mappings = 1
+" This is mere a copy of the default mappings, but it's useful if you'd like
+" to use its mappings as a trigger for lazy load of some plugin manager such as
+" dein.vim.
+imap <C-g><C-y> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
+imap <C-g><C-e> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
+imap <expr> <C-y> pumvisible() ? '<Plug>(snatch-completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
+imap <expr> <C-e> pumvisible() ? '<Plug>(snatch-completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+```

--- a/README.md
+++ b/README.md
@@ -117,18 +117,10 @@ cmap <C-o> <Plug>(snatch-operator)
 smap <C-y> <Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
 smap <C-e> <Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
 
-" **Notice**
-" * When pumvisible() returns 1, <C-y> and <C-e> should behave as you read at
-"   each CTRL-Y and CTRL-E in `:h popupmenu-keys`; thus, <expr> will be needed.
-" * The mapping examples after the default ones below will be written without
-"   this <expr>-workaround for pumvisible as the workaround is understood.
-" * `<SID>` lets you map both <C-y>/<C-e> non-recursively and
-"   <Plug>(snatch-mapping) recursively to the same {rhs}. (Practically, you can
-"   omit this <SID>-workaround here as {lhs} is the very same key of {rhs}.)
-inoremap <SID>(C-y) <C-y>
-inoremap <SID>(C-e) <C-e>
-imap <expr> <C-y> pumvisible() ? '<SID>(C-y)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
-imap <expr> <C-e> pumvisible() ? '<SID>(C-e)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+imap <C-g><C-y> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
+imap <C-g><C-e> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
+imap <expr> <C-y> pumvisible() ? '<Plug>(snatch-completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
+imap <expr> <C-e> pumvisible() ? '<Plug>(snatch-completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
 ```
 
 Or define mappings as your preference.

--- a/doc/snatch.txt
+++ b/doc/snatch.txt
@@ -274,6 +274,37 @@ s_<Plug>(snatch-oneshot-hor-or-reg-here)
         detection for horizontal motion is one-shot: once cursor moves
         vertically, you have to use |registers| to |snatch| text.
 
+i_<Plug>(snatch-completion-confirm)       *i_<Plug>(snatch-completion-confirm)*
+
+        Confirm the currently selected match. It is just a wrapper of `<C-y>`
+        to describe the behavior; thus, make sure `pumvisible()` returns `1` to
+        use this mapping. See also |popupmenu-keys|.
+>
+        imap <expr> <C-y> pumvisible()
+        \ ? '<Plug>(snatch-completion-confirm)'
+        \ : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
+>
+i_<Plug>(snatch-completion-cancel)         *i_<Plug>(snatch-completion-cancel)*
+
+        Cancel completion. It is just a wrapper of `<C-e>` to describe the
+        behavior; thus, make sure `pumvisible()` returns `1` to use this mapping.
+        See also |popupmenu-keys|.
+>
+        imap <expr> <C-e> pumvisible()
+        \ ? '<Plug>(snatch-completion-cancel)'
+        \ : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+>
+i_<Plug>(snatch-by-force)                           *i_<Plug>(snatch-by-force)*
+
+        Whether or not popup menu is visible (usually in completion), make
+        sure it's ready to start |snatching| (or any other |Insert-mode| mapping
+        which forgets to deal with popup menu).
+>
+        imap <C-g><C-y>
+        \ <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
+        imap <C-g><C-e>
+        \ <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
+>
 ------------------------------------------------------------------------------
 AUTOCMD                                                         *snatch-autocmd*
 

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -104,6 +104,8 @@ imap <Plug>(snatch-oneshot-hor-or-reg-ctrl-y) <SID>(snatch-oneshot-hor-or-reg-ct
 imap <Plug>(snatch-oneshot-hor-or-reg-ctrl-e) <SID>(snatch-oneshot-hor-or-reg-ctrl-e)
 imap <Plug>(snatch-oneshot-hor-or-reg-here)   <SID>(snatch-oneshot-hor-or-reg-here)
 
+inoremap <Plug>(snatch-completion-confirm) <C-y>
+inoremap <Plug>(snatch-completion-cancel) <C-e>
 inoremap <SID>(completion-keep-match) <space><BS>
 imap <expr> <Plug>(snatch-by-force) pumvisible() ? '<SID>(completion-keep-match)' : ''
 
@@ -132,9 +134,7 @@ if !get(g:, 'snatch#no_default_mappings', 0)
   imap <C-g><C-y> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
   imap <C-g><C-e> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
 
-  inoremap <SID>(completion-confirm) <C-y>
-  inoremap <SID>(completion-cancel) <C-e>
-  imap <expr> <C-y> pumvisible() ? '<SID>(completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
-  imap <expr> <C-e> pumvisible() ? '<SID>(completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+  imap <expr> <C-y> pumvisible() ? '<Plug>(snatch-completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
+  imap <expr> <C-e> pumvisible() ? '<Plug>(snatch-completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
 endif
 

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -126,15 +126,15 @@ if !get(g:, 'snatch#no_default_mappings', 0)
   xmap z: <Plug>(snatch-into-cmdline)
   cmap <C-o> <Plug>(snatch-operator)
 
-  inoremap <SID>(completion-confirm) <C-y>
-  inoremap <SID>(completion-cancel) <C-e>
-  imap <expr> <C-y> pumvisible() ? '<SID>(completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
-  imap <expr> <C-e> pumvisible() ? '<SID>(completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+  smap <C-y> <Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
+  smap <C-e> <Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
 
   imap <C-g><C-y> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
   imap <C-g><C-e> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
 
-  smap <C-y> <Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
-  smap <C-e> <Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
+  inoremap <SID>(completion-confirm) <C-y>
+  inoremap <SID>(completion-cancel) <C-e>
+  imap <expr> <C-y> pumvisible() ? '<SID>(completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
+  imap <expr> <C-e> pumvisible() ? '<SID>(completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
 endif
 

--- a/plugin/snatch.vim
+++ b/plugin/snatch.vim
@@ -104,6 +104,9 @@ imap <Plug>(snatch-oneshot-hor-or-reg-ctrl-y) <SID>(snatch-oneshot-hor-or-reg-ct
 imap <Plug>(snatch-oneshot-hor-or-reg-ctrl-e) <SID>(snatch-oneshot-hor-or-reg-ctrl-e)
 imap <Plug>(snatch-oneshot-hor-or-reg-here)   <SID>(snatch-oneshot-hor-or-reg-here)
 
+inoremap <SID>(completion-keep-match) <space><BS>
+imap <expr> <Plug>(snatch-by-force) pumvisible() ? '<SID>(completion-keep-match)' : ''
+
 snoremap <SID>(erase) <space><BS>
 
 smap <Plug>(snatch-horizontal-ctrl-y)         <SID>(erase)<SID>(snatch-horizontal-ctrl-y)
@@ -127,6 +130,10 @@ if !get(g:, 'snatch#no_default_mappings', 0)
   inoremap <SID>(completion-cancel) <C-e>
   imap <expr> <C-y> pumvisible() ? '<SID>(completion-confirm)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)'
   imap <expr> <C-e> pumvisible() ? '<SID>(completion-cancel)' : '<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)'
+
+  imap <C-g><C-y> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
+  imap <C-g><C-e> <Plug>(snatch-by-force)<Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
+
   smap <C-y> <Plug>(snatch-oneshot-hor-or-reg-ctrl-y)
   smap <C-e> <Plug>(snatch-oneshot-hor-or-reg-ctrl-e)
 endif


### PR DESCRIPTION
# Note

```vim
imap <expr> <Plug>(snatch-by-force) pumvisible() ? '<SID>(completion-keep-match)' : ''
```
 could be converted into

```vim
imap <Plug>(snatch-by-force) <SID>(completion-keep-match)
```

in short; however, this is over-optimization because the workaround `<SID>(completion-keep-match)` only happens to be equal to `<space><BS>`, which also accidentally hardly causes any side effects. Addition to that, current mapping as `<expr>` with ternary operator is more self-documenting: if popup menu is visible, keep matched words (implicitly closing popup menu window); otherwise, do nothing.
