### PR TITLE
fix(pre_keys): replace `:normal` with `feedkeys()`

### DIFF
--- a/autoload/snatch/common.vim
+++ b/autoload/snatch/common.vim
@@ -88,7 +88,7 @@ function! snatch#common#prepare(config) abort
   const pre_keys = get(a:config, 'pre_keys', '')
   call s:pre_keys.set(pre_keys)
   if pre_keys !=# ''
-    exe 'norm!' pre_keys
+    call feedkeys(pre_keys, 'ni')
   endif
 
   " Note: Although `:stopinsert` above, and even the success of command,


### PR DESCRIPTION
This update lets user, by `gi`, to the last InsertLeave position to
snatch.